### PR TITLE
Make the dynamic framework built by Carthage support iOS 9 & Update README

### DIFF
--- a/ListDiff.xcodeproj/project.pbxproj
+++ b/ListDiff.xcodeproj/project.pbxproj
@@ -357,6 +357,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ListDiff/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.lxcid.ListDiff;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -379,6 +380,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ListDiff/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.lxcid.ListDiff;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ The motivation for this project came from the following [challenge](https://gith
 swift package generate-xcodeproj
 ```
 
+## Installation
+
+#### CocoaPods
+
+```ruby
+pod 'ListDiff'
+```
+
+#### Carthage
+
+```ogdl
+github "lxcid/ListDiff" "master"
+```
+
 ## Usage
 
 ```swift


### PR DESCRIPTION
- Make the dynamic framework built by Carthage support iOS 9.
- Add installation instructions in README.