### PR TITLE
#6 adopt walkarounds for collection view

### DIFF
--- a/ListDiff.xcodeproj/project.pbxproj
+++ b/ListDiff.xcodeproj/project.pbxproj
@@ -11,6 +11,14 @@
 		A6FD5D511F8B710A006A2CDC /* ListDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FD5D501F8B710A006A2CDC /* ListDiffTests.swift */; };
 		A6FD5D531F8B710A006A2CDC /* ListDiff.h in Headers */ = {isa = PBXBuildFile; fileRef = A6FD5D451F8B710A006A2CDC /* ListDiff.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A6FD5D5E1F8B71C1006A2CDC /* ListDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6FD5D5D1F8B71C1006A2CDC /* ListDiff.swift */; };
+		CCA06441212EB7F500CAB660 /* ListDiffStressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA06440212EB7F500CAB660 /* ListDiffStressTests.swift */; };
+		CCA06447212EC12400CAB660 /* ObjCExceptionCatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA06445212EC12400CAB660 /* ObjCExceptionCatcher.swift */; };
+		CCA06448212EC12400CAB660 /* ObjCExceptionCatcherHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = CCA06446212EC12400CAB660 /* ObjCExceptionCatcherHelper.m */; };
+		CCA0644F212EC3FA00CAB660 /* Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA0644B212EC3FA00CAB660 /* Cell.swift */; };
+		CCA06450212EC3FA00CAB660 /* CollectionViewUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA0644C212EC3FA00CAB660 /* CollectionViewUpdater.swift */; };
+		CCA06451212EC3FA00CAB660 /* CellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA0644D212EC3FA00CAB660 /* CellData.swift */; };
+		CCA06452212EC3FA00CAB660 /* CellDataGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA0644E212EC3FA00CAB660 /* CellDataGenerator.swift */; };
+		CCA06454212EC53100CAB660 /* CellDataGeneratorResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA06453212EC53100CAB660 /* CellDataGeneratorResult.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,6 +39,16 @@
 		A6FD5D501F8B710A006A2CDC /* ListDiffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDiffTests.swift; sourceTree = "<group>"; };
 		A6FD5D521F8B710A006A2CDC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A6FD5D5D1F8B71C1006A2CDC /* ListDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ListDiff.swift; path = Sources/ListDiff.swift; sourceTree = SOURCE_ROOT; };
+		CCA06440212EB7F500CAB660 /* ListDiffStressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListDiffStressTests.swift; sourceTree = "<group>"; };
+		CCA06443212EC12300CAB660 /* ListDiffTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ListDiffTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		CCA06444212EC12300CAB660 /* ObjCExceptionCatcherHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcherHelper.h; sourceTree = "<group>"; };
+		CCA06445212EC12400CAB660 /* ObjCExceptionCatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCExceptionCatcher.swift; sourceTree = "<group>"; };
+		CCA06446212EC12400CAB660 /* ObjCExceptionCatcherHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjCExceptionCatcherHelper.m; sourceTree = "<group>"; };
+		CCA0644B212EC3FA00CAB660 /* Cell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cell.swift; sourceTree = "<group>"; };
+		CCA0644C212EC3FA00CAB660 /* CollectionViewUpdater.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewUpdater.swift; sourceTree = "<group>"; };
+		CCA0644D212EC3FA00CAB660 /* CellData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellData.swift; sourceTree = "<group>"; };
+		CCA0644E212EC3FA00CAB660 /* CellDataGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CellDataGenerator.swift; sourceTree = "<group>"; };
+		CCA06453212EC53100CAB660 /* CellDataGeneratorResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellDataGeneratorResult.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,7 +102,9 @@
 			isa = PBXGroup;
 			children = (
 				A6FD5D501F8B710A006A2CDC /* ListDiffTests.swift */,
+				CCA06442212EB81100CAB660 /* ListDiffStressTests */,
 				A6FD5D521F8B710A006A2CDC /* Info.plist */,
+				CCA06443212EC12300CAB660 /* ListDiffTests-Bridging-Header.h */,
 			);
 			name = ListDiffTests;
 			path = Tests/ListDiffTests;
@@ -96,6 +116,38 @@
 				A6FD5D5D1F8B71C1006A2CDC /* ListDiff.swift */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		CCA06442212EB81100CAB660 /* ListDiffStressTests */ = {
+			isa = PBXGroup;
+			children = (
+				CCA06440212EB7F500CAB660 /* ListDiffStressTests.swift */,
+				CCA0644A212EC3A100CAB660 /* Support */,
+			);
+			path = ListDiffStressTests;
+			sourceTree = "<group>";
+		};
+		CCA06449212EC39600CAB660 /* ObjCExceptionCatcher */ = {
+			isa = PBXGroup;
+			children = (
+				CCA06445212EC12400CAB660 /* ObjCExceptionCatcher.swift */,
+				CCA06444212EC12300CAB660 /* ObjCExceptionCatcherHelper.h */,
+				CCA06446212EC12400CAB660 /* ObjCExceptionCatcherHelper.m */,
+			);
+			path = ObjCExceptionCatcher;
+			sourceTree = "<group>";
+		};
+		CCA0644A212EC3A100CAB660 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				CCA0644B212EC3FA00CAB660 /* Cell.swift */,
+				CCA0644D212EC3FA00CAB660 /* CellData.swift */,
+				CCA0644E212EC3FA00CAB660 /* CellDataGenerator.swift */,
+				CCA06453212EC53100CAB660 /* CellDataGeneratorResult.swift */,
+				CCA0644C212EC3FA00CAB660 /* CollectionViewUpdater.swift */,
+				CCA06449212EC39600CAB660 /* ObjCExceptionCatcher */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -165,6 +217,7 @@
 					};
 					A6FD5D4A1F8B710A006A2CDC = {
 						CreatedOnToolsVersion = 9.0;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -217,6 +270,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCA06441212EB7F500CAB660 /* ListDiffStressTests.swift in Sources */,
+				CCA06447212EC12400CAB660 /* ObjCExceptionCatcher.swift in Sources */,
+				CCA06450212EC3FA00CAB660 /* CollectionViewUpdater.swift in Sources */,
+				CCA06452212EC3FA00CAB660 /* CellDataGenerator.swift in Sources */,
+				CCA06454212EC53100CAB660 /* CellDataGeneratorResult.swift in Sources */,
+				CCA0644F212EC3FA00CAB660 /* Cell.swift in Sources */,
+				CCA06451212EC3FA00CAB660 /* CellData.swift in Sources */,
+				CCA06448212EC12400CAB660 /* ObjCExceptionCatcherHelper.m in Sources */,
 				A6FD5D511F8B710A006A2CDC /* ListDiffTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -394,11 +455,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/ListDiffTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.lxcid.ListDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/ListDiffTests/ListDiffTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -408,11 +472,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/ListDiffTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.lxcid.ListDiffTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/ListDiffTests/ListDiffTests-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ListDiff.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ListDiff.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/ListDiff.swift
+++ b/Sources/ListDiff.swift
@@ -205,3 +205,33 @@ public enum List {
         return result
     }
 }
+
+public extension List.Result {
+    func forBatchUpdates() -> List.Result {
+        var result = self
+        result.mutatingForBatchUpdates()
+        return result
+    }
+    
+    private mutating func mutatingForBatchUpdates() {
+        // convert move+update to delete+insert, respecting the from/to of the move
+        for (index, move) in moves.enumerated().reversed() {
+            if let _ = updates.remove(move.from) {
+                moves.remove(at: index)
+                deletes.insert(move.from)
+                inserts.insert(move.to)
+            }
+        }
+        
+        // iterate all new identifiers. if its index is updated, delete from the old index and insert the new index
+        for (key, oldIndex) in oldMap {
+            if updates.contains(oldIndex), let newIndex = newMap[key] {
+                deletes.insert(oldIndex)
+                inserts.insert(newIndex)
+            }
+        }
+        
+        updates.removeAll()
+    }
+}
+

--- a/Tests/ListDiffTests/ListDiffStressTests/ListDiffStressTests.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/ListDiffStressTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import UIKit
+@testable import ListDiff
+
+private let collectionSize = 100
+private let iterationsCount = 1000
+
+final class ListDiffStressTests: XCTestCase {
+    func test_listDiff_doesNotCrashUICollectionViewAndReturnsCorrectDiff() {
+        let expectations = (0..<iterationsCount).map {
+            expectation(description: "async expectation of iteration \($0)")
+        }
+        
+        performTests(expectations: expectations)
+        waitForExpectations(timeout: 30)
+    }
+    
+    // MARK: - Private
+    private func performTests(expectations: [XCTestExpectation]) {
+        performTest(
+            index: 0,
+            expectations: expectations,
+            previousCellDataList: []
+        )
+    }
+    
+    private func performTest(
+        index: Int,
+        expectations: [XCTestExpectation],
+        previousCellDataList: [CellData])
+    {
+        guard index < expectations.count else { return }
+        
+        autoreleasepool {
+            print("testing iteration \(index)")
+            
+            let cellDataGenerator = CellDataGenerator()
+            
+            // Given
+            let cellDataGeneratorResult: CellDataGeneratorResult
+            if index == 0 {
+                cellDataGeneratorResult = cellDataGenerator
+                    .generateCellData(count: collectionSize)
+            } else {
+                cellDataGeneratorResult = cellDataGenerator
+                    .performRandomActionsOnCellData(
+                        previousCellDataList,
+                        minimumCountAfterActions: collectionSize / 10,
+                        maximumCountAfterActions: collectionSize * 10
+                )
+            }
+            
+            print("  from \(cellDataGeneratorResult.from.count), to: \(cellDataGeneratorResult.to.count).")
+            
+            print("  deletes \(cellDataGeneratorResult.deletes), "
+                + "inserts: \(cellDataGeneratorResult.inserts), "
+                + "moves \(cellDataGeneratorResult.moves), "
+                + "updates: \(cellDataGeneratorResult.updates)."
+            )
+            
+            // When
+            let collectionViewUpdater = CollectionViewUpdater()
+            collectionViewUpdater.updateCollectionView(
+                from: cellDataGeneratorResult.from,
+                to: cellDataGeneratorResult.to,
+                completion: { [weak self] result in
+                    // Then
+                    switch result {
+                    case let .exception(exception):
+                        XCTFail("Failed to update collection view using ListDiff. exception: \(exception)")
+                        print("__________________________________________________")
+                    case let .success(visibleCellDataList, expectedCellDataList):
+                        XCTAssert(
+                            visibleCellDataList.count == expectedCellDataList.count,
+                            "Update the layout to fit all cells in the screen"
+                        )
+                        
+                        let zippedCellDataLists = zip(visibleCellDataList, expectedCellDataList)
+                        for (index, (visibleCellData, expectedCellData)) in zippedCellDataLists.enumerated() {
+                            XCTAssert(
+                                visibleCellData == expectedCellData,
+                                "visible cell data and expected cell data are not in sync at index: \(index)"
+                            )
+                        }
+                    }
+                    
+                    print("")
+                    
+                    expectations[index].fulfill()
+                    
+                    self?.performTest(
+                        index: index + 1,
+                        expectations: expectations,
+                        previousCellDataList: cellDataGeneratorResult.to
+                    )
+                }
+            )
+        }
+    }
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/Cell.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/Cell.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+final class Cell: UICollectionViewCell {
+    var cellData: CellData?
+    
+    static let reuseIdentifier = "Cell.reuseIdentifier"
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/CellData.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/CellData.swift
@@ -1,0 +1,33 @@
+@testable import ListDiff
+import XCTest
+
+final class CellData: Equatable, Diffable {
+    // MARK: - Properties
+    let title: String
+    let subtitle: String
+    
+    // MARK: - Diffable
+    let diffIdentifier: AnyHashable
+    
+    // MARK: - Init
+    init(
+        diffIdentifier: AnyHashable,
+        title: String,
+        subtitle: String)
+    {
+        self.title = title
+        self.subtitle = subtitle
+        self.diffIdentifier = diffIdentifier
+    }
+    
+    // MARK: - Equatable
+    static func == (lhs: CellData, rhs: CellData) -> Bool {
+        XCTAssert(
+            lhs.diffIdentifier == rhs.diffIdentifier,
+            "We expect the algorythm to compare items only with same `diffIdentifier`"
+        )
+        
+        return lhs.title == rhs.title
+            && lhs.subtitle == rhs.subtitle
+    }
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/CellDataGenerator.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/CellDataGenerator.swift
@@ -1,0 +1,135 @@
+final class CellDataGenerator {
+    func generateCellData(count: Int) -> CellDataGeneratorResult {
+        var cellDataList = [CellData]()
+        
+        insertCellData(
+            into: &cellDataList,
+            count: count
+        )
+        
+        return CellDataGeneratorResult(
+            deletes: 0,
+            inserts: count,
+            moves: 0, updates: 0,
+            from: [],
+            to: cellDataList
+        ) 
+    }
+    
+    func performRandomActionsOnCellData(
+        _ cellDataList: [CellData],
+        minimumCountAfterActions: Int,
+        maximumCountAfterActions: Int)
+        -> CellDataGeneratorResult
+    {
+        var newCellDataList = cellDataList
+        
+        var inserts = Int.random() % maximumCountAfterActions / 2
+        insertCellData(into: &newCellDataList, count: inserts)
+        
+        var deletes = Int.random() % maximumCountAfterActions / 2
+        deleteCellData(from: &newCellDataList, count: &deletes)
+        
+        var moves = Int.random() % maximumCountAfterActions / 3
+        moveCellData(in: &newCellDataList, count: &moves)
+        
+        var updates = Int.random() % maximumCountAfterActions / 3
+        updateCellData(in: &newCellDataList, count: &updates)
+        
+        if newCellDataList.count < minimumCountAfterActions {
+            inserts += minimumCountAfterActions
+            insertCellData(into: &newCellDataList, count: minimumCountAfterActions)
+        }
+        
+        if newCellDataList.count > maximumCountAfterActions {
+            var extraItems = newCellDataList.count - maximumCountAfterActions
+            deleteCellData(from: &newCellDataList, count: &extraItems)
+            deletes += extraItems
+        }
+        
+        return CellDataGeneratorResult(
+            deletes: deletes,
+            inserts: inserts,
+            moves: moves,
+            updates: updates,
+            from: cellDataList,
+            to: newCellDataList
+        )
+    }
+    
+    // MARK: - Private
+    private func insertCellData(into cellDataList: inout [CellData], count: Int) {
+        for _ in 0 ..< count {
+            let cellData = CellData(
+                diffIdentifier: UUID().uuidString,
+                title: UUID().uuidString,
+                subtitle: UUID().uuidString
+            )
+            
+            if cellDataList.isEmpty {
+                cellDataList.append(cellData)
+            } else {
+                let randomIndex = Int.random() % cellDataList.count
+                cellDataList.insert(cellData, at: randomIndex)
+            }
+        }
+    }
+    
+    private func deleteCellData(from cellDataList: inout [CellData], count: inout Int) {
+        for i in 0 ..< count where !cellDataList.isEmpty {
+            let randomIndex = Int.random() % cellDataList.count
+            cellDataList.remove(at: randomIndex)
+            count = i + 1
+        }
+    }
+    
+    private func moveCellData(in cellDataList: inout [CellData], count: inout Int) {
+        for i in 0 ..< count where !cellDataList.isEmpty {
+            let randomFromIndex = Int.random() % cellDataList.count
+            let cellData = cellDataList.remove(at: randomFromIndex)
+            
+            if cellDataList.isEmpty {
+                cellDataList.append(cellData)
+            } else {
+                let randomToIndex = Int.random() % cellDataList.count
+                cellDataList.insert(cellData, at: randomToIndex)
+            }
+            count = i + 1
+        }
+    }
+    
+    private func updateCellData(in cellDataList: inout [CellData], count: inout Int) {
+        for i in 0 ..< count where !cellDataList.isEmpty {
+            let randomIndex = Int.random() % cellDataList.count
+            
+            let oldCellData = cellDataList[randomIndex]
+            
+            let newCellData = CellData(
+                diffIdentifier: oldCellData.diffIdentifier,
+                title: oldCellData.title + " *",
+                subtitle: oldCellData.subtitle
+            )
+            
+            cellDataList[randomIndex] = newCellData
+            count = i + 1
+        }
+    }
+}
+
+private extension Int {
+    static func random() -> Int {
+        let random = arc4random()
+        
+        if let intValue = Int(exactly: random) {
+            return intValue
+        } else {
+            // Int.max < UInt32.max (32-bit systems)
+            let maxUintRepresentableByInt = UInt32(Int32.max)
+            if random <= maxUintRepresentableByInt {
+                return Int(random)
+            } else {
+                return Int(random % maxUintRepresentableByInt)
+            }
+        }
+    }
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/CellDataGeneratorResult.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/CellDataGeneratorResult.swift
@@ -1,0 +1,8 @@
+struct CellDataGeneratorResult {
+    let deletes: Int
+    let inserts: Int
+    let moves: Int
+    let updates: Int
+    let from: [CellData]
+    let to: [CellData]
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/CollectionViewUpdater.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/CollectionViewUpdater.swift
@@ -1,0 +1,177 @@
+import XCTest
+import UIKit
+@testable import ListDiff
+import Foundation
+
+enum CollectionViewUpdaterResult {
+    case exception(NSException)
+    case success(visibleCellDataList: [CellData], expectedCellDataList: [CellData])
+}
+
+final class CollectionViewUpdater: NSObject, UICollectionViewDataSource {
+    // MARK: - State
+    private var cellData = [CellData]() // for UICollectionViewDataSource
+    private var collectionView: UICollectionView?
+    private var window: UIWindow?
+    
+    // MARK: - Internal
+    func updateCollectionView(
+        from: [CellData],
+        to: [CellData],
+        completion: @escaping (CollectionViewUpdaterResult) -> ())
+    {
+        let collectionView = makeAndReloadCollectionViewWith(cellData: from)
+        
+        let diff = List.diffing(
+            oldArray: from,
+            newArray: to
+        ).forBatchUpdates() // If you remove `forBatchUpdates`, `ListDiffStressTests` will start to fail
+        
+        performBatchUpdates(
+            of: collectionView,
+            cellDataList: to,
+            diff: diff,
+            completion: completion
+        )
+    }
+    
+    func cleanUp() {
+        cellData = []
+        collectionView?.dataSource = nil
+        collectionView?.removeFromSuperview()
+        collectionView = nil
+        window = nil
+    }
+
+    // MARK: - Private
+    private func makeAndReloadCollectionViewWith(
+        cellData: [CellData])
+        -> UICollectionView
+    {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.layer.speed = 100 // Speed up the animations
+        self.window = window
+        
+        let layout = UICollectionViewFlowLayout()
+        layout.itemSize = CGSize(width: 1, height: 1) // To fit all cells in the screen 
+        layout.minimumInteritemSpacing = 0.001
+        layout.minimumLineSpacing = 0.001
+        
+        let collectionView = UICollectionView(frame: window.frame, collectionViewLayout: layout)
+        self.collectionView = collectionView
+        window.addSubview(collectionView)
+        
+        self.cellData = cellData
+        collectionView.dataSource = self
+        collectionView.register(Cell.self, forCellWithReuseIdentifier: Cell.reuseIdentifier)
+        collectionView.reloadData()
+        
+        return collectionView
+    }
+    
+    private func performBatchUpdates(
+        of collectionView: UICollectionView,
+        cellDataList: [CellData],
+        diff: List.Result,
+        completion: @escaping (CollectionViewUpdaterResult) -> ())
+    {
+        var catchedException: NSException?
+        
+        ObjCExceptionCatcher.tryClosure(
+            tryClosure: {
+                tryPerformingBatchUpdates(
+                    of: collectionView,
+                    cellDataList: cellDataList,
+                    diff: diff
+                )
+            },
+            catchClosure: { exception in
+                catchedException = exception
+            },
+            finallyClosure: {
+                if let catchedException = catchedException {
+                    completion(
+                        .exception(catchedException)
+                    )
+                } else {
+                    let visibleIndexPaths = collectionView.indexPathsForVisibleItems.sorted { $0.row < $1.row }
+                    
+                    let visibleCellDataList: [CellData] = visibleIndexPaths.map {
+                        let cell = collectionView.cellForItem(at: $0) as! Cell
+                        return cell.cellData!
+                    }
+                    
+                    completion(
+                        .success(
+                            visibleCellDataList: visibleCellDataList,
+                            expectedCellDataList: cellDataList
+                        )
+                    )
+                }
+            }
+        )
+    }
+    
+    private func tryPerformingBatchUpdates(
+        of collectionView: UICollectionView,
+        cellDataList: [CellData],
+        diff: List.Result)
+    {
+        collectionView.performBatchUpdates(
+            _: {
+                self.cellData = cellDataList
+                
+                // Deletes
+                if !diff.deletes.isEmpty {
+                    collectionView.deleteItems(
+                        at: diff.deletes.map {
+                            IndexPath(item: $0, section: 0)
+                        }
+                    )
+                }
+                
+                // Inserts
+                if !diff.inserts.isEmpty {
+                    collectionView.insertItems(
+                        at: diff.inserts.map {
+                            IndexPath(item: $0, section: 0)
+                        }
+                    )
+                }
+                
+                // Moves
+                for move in diff.moves {
+                    collectionView.moveItem(
+                        at: IndexPath(item: move.from, section: 0),
+                        to: IndexPath(item: move.to, section: 0)
+                    )
+                }
+                
+                if !diff.updates.isEmpty {
+                    collectionView.reloadItems(
+                        at: diff.updates.map {
+                            IndexPath(item: $0, section: 0)
+                        }
+                    )
+                }
+            },
+           completion: { _ in }
+         )
+    }
+    
+    // MARK: - UICollectionViewDataSource
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return cellData.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Cell.reuseIdentifier, for: indexPath) as! Cell
+        cell.cellData = cellData[indexPath.row]
+        return cell
+    }
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcher.swift
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcher.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public final class ObjCExceptionCatcher {
+    public static func tryClosure(
+        tryClosure: () -> (),
+        catchClosure: @escaping (NSException) -> (),
+        finallyClosure: @escaping () -> () = {})
+    {
+        ObjCExceptionCatcherHelper.`try`(tryClosure, catch: catchClosure, finally: finallyClosure)
+    }
+}

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcherHelper.h
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcherHelper.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface ObjCExceptionCatcherHelper: NSObject
+
++ (void)try:(nonnull NS_NOESCAPE void(^)(void))tryBlock
+      catch:(nonnull void(^)(NSException * _Nonnull))catchBlock
+    finally:(nonnull void(^)(void))finallyBlock;
+
+@end

--- a/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcherHelper.m
+++ b/Tests/ListDiffTests/ListDiffStressTests/Support/ObjCExceptionCatcher/ObjCExceptionCatcherHelper.m
@@ -1,0 +1,20 @@
+#import "ObjCExceptionCatcherHelper.h"
+
+@implementation ObjCExceptionCatcherHelper
+
++ (void)try:(nonnull NS_NOESCAPE void(^)(void))tryBlock
+      catch:(nonnull void(^)(NSException * _Nonnull))catchBlock
+    finally:(nonnull void(^)(void))finallyBlock
+{
+    @try {
+        tryBlock();
+    }
+    @catch (NSException *exception) {
+        catchBlock(exception);
+    }
+    @finally {
+        finallyBlock();
+    }
+}
+
+@end

--- a/Tests/ListDiffTests/ListDiffTests-Bridging-Header.h
+++ b/Tests/ListDiffTests/ListDiffTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "ObjCExceptionCatcherHelper.h"


### PR DESCRIPTION
Adopted [this](https://github.com/Instagram/IGListKit/blob/master/Source/Common/IGListIndexSetResult.m#L43) walkarounds

Added stress tests of continous random collection view updates
```

testing iteration 3
  from 10, to: 10.
  deletes 339, inserts: 339, moves 274, updates: 79.

testing iteration 4
  from 10, to: 87.
  deletes 93, inserts: 170, moves 47, updates: 95.

testing iteration 5
  from 87, to: 178.
  deletes 92, inserts: 183, moves 296, updates: 127.

testing iteration 6
  from 178, to: 222.
  deletes 139, inserts: 183, moves 129, updates: 277.

testing iteration 7
  from 222, to: 260.
  deletes 307, inserts: 345, moves 96, updates: 92.

testing iteration 8
  from 260, to: 146.
  deletes 323, inserts: 209, moves 74, updates: 108.

testing iteration 9
  from 146, to: 231.
  deletes 398, inserts: 483, moves 179, updates: 39.

testing iteration 10
  from 231, to: 488.
  deletes 215, inserts: 472, moves 249, updates: 17.

testing iteration 11
  from 488, to: 104.
  deletes 496, inserts: 112, moves 215, updates: 22.

testing iteration 12
  from 104, to: 189.
  deletes 68, inserts: 153, moves 143, updates: 301.

```